### PR TITLE
fix: remember date when editing a transaction

### DIFF
--- a/libs/shared/common/src/lib/components/datepicker/calendar.component.ts
+++ b/libs/shared/common/src/lib/components/datepicker/calendar.component.ts
@@ -11,12 +11,13 @@ import { TooltipModule } from '../tooltip';
 })
 export class CalendarComponent {
   #epoch = new Date();
+  view = signal<Date>(this.#epoch);
   selectedDate = signal<Date>(this.#epoch);
   @Input() set selectedDateInput(value: Date) {
     this.selectedDate.set(value);
+    this.view.set(value);
   }
   readonly daysOfWeek = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
-  view = signal<Date>(this.#epoch);
   calendarDays = computed(() => {
     const currentMonthFirstDay = new Date(this.view().getFullYear(), this.view().getMonth(), 1).getDay() - 1;
     const firstDay = new Date(this.view().getFullYear(), this.view().getMonth(), currentMonthFirstDay * -1);


### PR DESCRIPTION
Closes #104 

### Developer Checklist (Definition of Done)

*Issue*

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

*Code*

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted

*PR*

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., bug, feature) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written

### Summary of changes
- Edit Transaction now takes the calendar to the date when the transaction was entered

### Screenshots
[104-fix-date-rememberence.webm](https://github.com/usamazansari/expenses-tracker/assets/98811057/71c8e503-a8de-4dfe-9898-3db1844c705d)


### Additional notes for the reviewer(s)
- N/A
